### PR TITLE
Fix name of German language (languages.json)

### DIFF
--- a/languages.json
+++ b/languages.json
@@ -36,7 +36,7 @@
             "authors" : ["bhz_ema#8181"]
         },
         {
-            "name": "Deutsche",
+            "name": "Deutsch",
             "code": "de",
             "flag": "de",
             "live": true,


### PR DESCRIPTION
The proper translation for "German" is "Deutsch" and not "Deutsche". 
"Deutsche" can be used only in a context like "German language" (= "Deutsche Sprache"), but not as a single word for this meaning.