### PR TITLE
Fix some placeholders (vi.json, tr.json)

### DIFF
--- a/tr.json
+++ b/tr.json
@@ -185,7 +185,7 @@
             },
             "view" : {
                 "title" : "Mağaza Rotasyonu",
-                "line1" : "Bu, Fortnite Battle Royale için [date]in item shop rotasyonu.",
+                "line1" : "Bu, Fortnite Battle Royale için [date] item shop rotasyonu.",
                 "line2" : "Bu konuda daha fazla bilgi görmek için bir kozmetike tıklayın.",
                 "today-button" : "Günün Eşya Mağazası"
             }

--- a/tr.json
+++ b/tr.json
@@ -185,7 +185,7 @@
             },
             "view" : {
                 "title" : "Mağaza Rotasyonu",
-                "line1" : "Bu, Fortnite Battle Royale için [tarih]in item shop rotasyonu.",
+                "line1" : "Bu, Fortnite Battle Royale için [date]in item shop rotasyonu.",
                 "line2" : "Bu konuda daha fazla bilgi görmek için bir kozmetike tıklayın.",
                 "today-button" : "Günün Eşya Mağazası"
             }

--- a/vi.json
+++ b/vi.json
@@ -80,7 +80,7 @@
             },
             "languagePicker" : {
                 "title" : "Chọn Ngôn Ngữ",
-                "currentLanguage" : "Bạn hiện đang sử dụng [ngôn ngữ]."
+                "currentLanguage" : "Bạn hiện đang sử dụng [language]."
             }
         },
         "home" : {

--- a/vi.json
+++ b/vi.json
@@ -127,7 +127,7 @@
             },
             "view" : {
                 "title" : "Xoay vòng cửa hàng",
-                "line1" : "Đây là vòng quay của cửa hàng vật phẩm [ngày] cho Fortnite Battle Royale. ",
+                "line1" : "Đây là vòng quay của cửa hàng vật phẩm [date] cho Fortnite Battle Royale. ",
                 "line2" : "Nhấp vào một mỹ phẩm để xem thêm thông tin về nó.",
                 "today-button" : "Cửa hàng vật phẩm hôm nay"
             }


### PR DESCRIPTION
Some placeholders (`[date]`, `[language]`) were translated in `vi.json` and `tr.json`. I've fixed that.