### PR TITLE
Fix brand names being translated in nav.about (vi.json)

### DIFF
--- a/vi.json
+++ b/vi.json
@@ -69,8 +69,8 @@
                 "about" : "Về fnbr.co",
                 "privacy" : "Chính Sách Bảo Mật",
                 "donate" : "Tặng",
-                "discord" : "Bất Hòa",
-                "twitter" : "Hát Líu Lo"
+                "discord" : "Discord",
+                "twitter" : "Twitter"
             },
             "api" : "api",
             "account" : {


### PR DESCRIPTION
`Discord` and `Twitter` are brand names that can't be translated. I've assured this through research and you can see that these brand names are also used in other phrases in this file.