### PR TITLE
Fix not all nav items being lowercase (multiple languages)

### DIFF
--- a/da.json
+++ b/da.json
@@ -49,35 +49,35 @@
             "translationIncomplete" : "Ikke alt tekst på denne side vil blive oversat"
         },
         "nav" : {
-            "home" : "Hjem",
-            "shop" : "Butik",
+            "home" : "hjem",
+            "shop" : "butik",
             "cosmetics" : {
-                "dropdown" : "Kosmetikker",
-                "upcoming" : "Kommende",
-                "list" : "Liste",
+                "dropdown" : "kosmetikker",
+                "upcoming" : "kommende",
+                "list" : "liste",
                 "png" : "png",
-                "gallery" : "Galleri",
-                "icons" : "Ikoner",
-                "reminders" : "Påmindelser",
-                "history" : "Butikshistorie"
+                "gallery" : "galleri",
+                "icons" : "ikoner",
+                "reminders" : "påmindelser",
+                "history" : "butikshistorie"
             },
-            "news" : "Nyheder",
-            "modes" : "Tilstande",
-            "randomiser" : "Tilfældig",
+            "news" : "nyheder",
+            "modes" : "tilstande",
+            "randomiser" : "tilfældig",
             "about" : {
-                "dropdown" : "Om",
-                "translate" : "Oversæt",
-                "about" : "Om fnbr.co",
-                "privacy" : "Fortrolighedspolitik",
+                "dropdown" : "om",
+                "translate" : "oversæt",
+                "about" : "om fnbr.co",
+                "privacy" : "fortrolighedspolitik",
                 "donate" : "Donere",
                 "discord" : "Discord",
                 "twitter" : "Twitter"
             },
             "api" : "api",
             "account" : {
-                "dropdown" : "Konto",
-                "account" : "Konto",
-                "logout" : "Log ud"
+                "dropdown" : "konto",
+                "account" : "konto",
+                "logout" : "log ud"
             },
             "languagePicker" : {
                 "trigger" : "Sprog",

--- a/fi.json
+++ b/fi.json
@@ -68,7 +68,7 @@
                 "dropdown" : "meistä",
                 "translate" : "käännös",
                 "about" : "meistä fnbr.co",
-                "privacy" : "Yksityisyyskäytäntö",
+                "privacy" : "yksityisyyskäytäntö",
                 "donate" : "Lahjoita",
                 "discord" : "Discord",
                 "twitter" : "Twitter"

--- a/fr.json
+++ b/fr.json
@@ -61,7 +61,7 @@
                 "reminders" : "rappels",
                 "history" : "historique"
             },
-            "news" : "Nouvelles",
+            "news" : "nouvelles",
             "modes" : "modes",
             "randomiser" : "randomiseur",
             "about" : {
@@ -76,8 +76,8 @@
             "api" : "api",
             "account" : {
                 "dropdown" : "menu déroulant",
-                "account" : "Compte",
-                "logout" : "Se Déconnecter"
+                "account" : "compte",
+                "logout" : "se déconnecter"
             },
             "languagePicker" : {
                 "trigger" : "language",

--- a/hu.json
+++ b/hu.json
@@ -67,16 +67,16 @@
             "about": {
                 "dropdown": "about",
                 "about": "fnbr.co-ról",
-                "privacy": "Adatvédelmi irányelvek",
+                "privacy": "adatvédelmi irányelvek",
                 "donate": "Adományozz",
                 "discord": "Discord",
                 "twitter": "Twitter"
             },
             "api": "api",
             "account": {
-                "dropdown": "Fiók",
-                "account": "Fiók",
-                "logout": "Kijelentkezés"
+                "dropdown": "fiók",
+                "account": "fiók",
+                "logout": "kijelentkezés"
             },
             "languagePicker": {
                 "trigger": "Nyelv",

--- a/nl.json
+++ b/nl.json
@@ -63,7 +63,7 @@
             },
             "news" : "nieuws",
             "modes" : "modes",
-            "randomiser" : "willekeurige Items",
+            "randomiser" : "willekeurige items",
             "about" : {
                 "dropdown" : "over",
                 "about" : "over fnbr.co",

--- a/no.json
+++ b/no.json
@@ -52,8 +52,8 @@
             "home" : "hjem",
             "shop" : "butikk",
             "cosmetics" : {
-                "dropdown" : "Kosmetikker",
-                "upcoming" : "Kommende",
+                "dropdown" : "kosmetikker",
+                "upcoming" : "kommende",
                 "list" : "liste",
                 "png" : "png",
                 "gallery" : "galleri",

--- a/vi.json
+++ b/vi.json
@@ -49,25 +49,25 @@
             "translationIncomplete" : "Không phải tất cả văn bản trên trang này sẽ được dịch"
         },
         "nav" : {
-            "home" : "Nhà",
-            "shop" : "Cửa Tiệm",
+            "home" : "nhà",
+            "shop" : "cửa tiệm",
             "cosmetics" : {
-                "dropdown" : "Mỹ Phẩm",
-                "upcoming" : "Sắp Tới",
-                "list" : "Danh Sách",
+                "dropdown" : "mỹ phẩm",
+                "upcoming" : "sắp tới",
+                "list" : "danh sách",
                 "png" : "png",
-                "gallery" : "Bộ Sưu Tập",
-                "icons" : "Tượng ở Giáo Đường",
-                "reminders" : "Người Nhắc Lại",
-                "history" : "Lịch Sử Cửa Hàng"
+                "gallery" : "bộ sưu tập",
+                "icons" : "tượng ở giáo đường",
+                "reminders" : "người nhắc lại",
+                "history" : "lịch sử cửa hàng"
             },
-            "news" : "Tin Tức",
-            "modes" : "Âm Pháp",
-            "randomiser" : "Ngẫu Nhiên",
+            "news" : "tin tức",
+            "modes" : "âm pháp",
+            "randomiser" : "ngẫu nhiên",
             "about" : {
-                "dropdown" : "Trong Khoảng",
-                "about" : "Về fnbr.co",
-                "privacy" : "Chính Sách Bảo Mật",
+                "dropdown" : "trong khoảng",
+                "about" : "về fnbr.co",
+                "privacy" : "chính sách bảo mật",
                 "donate" : "Tặng",
                 "discord" : "Discord",
                 "twitter" : "Twitter"


### PR DESCRIPTION
Since the English localization doesn't use capital letters for navigation items, the same should apply to all other languages as well. This has been taken into account by most authors, but some language files don't follow this scheme. I've fixed this for `nl.json`, `da.json`, `fi.json`, `fr.json`, `hu.json`, `no.json` and `vi.json`.